### PR TITLE
Update to Swift Package to Swift 5

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.2
+// swift-tools-version:5.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -15,7 +15,7 @@ let package = Package(
         .target(
             name: "Adhan",
             path: "Sources",
-            exclude: ["AdhanObjc.swift"]
+            exclude: ["AdhanObjc.swift", "Info.plist"]
         ),
         .testTarget(
             name: "Tests",


### PR DESCRIPTION
I couldn't compile with Xcode 12.5 with some mixed Swift Packages. Setting the Swift Package toolchain version to Swift 5 resolved the issue. This also seems like the right way to go as well since it is the first version of ABI stability for better forward/backward compatibility.

I also fixed a compiler warning of the `Info.plist` getting unnecessarily included in the package.