### PR TITLE
Raise watchOS deployment target to 9.0 (1.4.0 + platforms)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,16 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
     name: "Adhan",
+    platforms: [
+        .iOS(.v13),
+        .macOS(.v10_13),
+        .tvOS(.v12),
+        .watchOS(.v9),
+    ],
     products: [
         .library(
             name: "Adhan",


### PR DESCRIPTION
watchOS 6.0–8.0 are below the minimum supported by recent SDKs (Xcode 16+/26 require watchOS ≥ 9.0), producing a fatal error:

"The watchOS Simulator deployment target 'WATCHOS_DEPLOYMENT_TARGET' is set to 8.0, but the range of supported deployment target versions is 9.0 to 27.0.x."

Proposed fix bumps the floor to .watchOS(.v9).
