### PR TITLE
Raise watchOS deployment target to 9.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
         .iOS(.v13),
         .macOS(.v10_13),
         .tvOS(.v12),
-        .watchOS(.v6),
+        .watchOS(.v9),
         .visionOS(.v1),
     ],
     products: [


### PR DESCRIPTION
watchOS 6.0–8.0 fall below the minimum supported by recent SDKs (Xcode 16+ requires watchOS ≥ 9.0), which produces a fatal `WATCHOS_DEPLOYMENT_TARGET is set to X, but the range of supported deployment target versions is 9.0 to …` error when a consumer builds the watchOS slice.

This raises the floor to `.watchOS(.v9)`. Manifest-only — no source or behavior changes.