### PR TITLE
docs: clarify 1/7 rule applies at or above 55° latitude

### DIFF
--- a/METHODS.md
+++ b/METHODS.md
@@ -39,7 +39,7 @@ Preset calculation parameters for different regions.
 | dubai | Used in the UAE. Slightly earlier Fajr time and slightly later Isha time with angles of 18.2° for Fajr and Isha in addition to 3 minute offsets for sunrise, Dhuhr, Asr, and Maghrib. |
 | qatar | Same Isha interval as `ummAlQura` but with the standard Fajr time using an angle of 18°. |
 | kuwait | Standard Fajr time with an angle of 18°. Slightly earlier Isha time with an angle of 17.5°. |
-| moonsightingCommittee | Method developed by Khalid Shaukat, founder of Moonsighting Committee Worldwide. Uses standard 18° angles for Fajr and Isha in addition to seasonal adjustment values. This method automatically applies the 1/7 approximation rule for locations above 55° latitude. Recommended for North America and the UK. |
+| moonsightingCommittee | Method developed by Khalid Shaukat, founder of Moonsighting Committee Worldwide. Uses standard 18° angles for Fajr and Isha in addition to seasonal adjustment values. This method automatically applies the 1/7 approximation rule for locations at or above 55° latitude. Recommended for North America and the UK. |
 | singapore | Used in Singapore, Malaysia, and Indonesia. Early Fajr time with an angle of 20° and standard Isha time with an angle of 18°. |
 | turkey | An approximation of the Diyanet method used in Turkey. This approximation is less accurate outside the region of Turkey. |
 | tehran | Institute of Geophysics, University of Tehran. Early Isha time with an angle of 14°. Slightly later Fajr time with an angle of 17.7°. Calculates Maghrib based on the sun reaching an angle of 4.5° below the horizon. |

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Implementations of Adhan in other languages can be found in the parent repo [Adh
 
 - Project > Package Dependencies
 - Add https://github.com/batoulapps/adhan-swift.git
-- Select "Up to Next Major" with "1.4.0"
+- Select "Up to Next Major" with "1.5.0"
 
 ## Usage
 

--- a/Sources/Models/CalculationMethod.swift
+++ b/Sources/Models/CalculationMethod.swift
@@ -55,7 +55,7 @@ import Foundation
   **moonsightingCommittee**
 
   Method developed by Khalid Shaukat, founder of Moonsighting Committee Worldwide. Uses standard 18° angles for Fajr and Isha in addition
-  to seasonal adjustment values. This method automatically applies the 1/7 approximation rule for locations above 55° latitude.
+  to seasonal adjustment values. This method automatically applies the 1/7 approximation rule for locations at or above 55° latitude.
   Recommended for North America and the UK.
 
   **northAmerica**

--- a/Sources/PrayerTimes.swift
+++ b/Sources/PrayerTimes.swift
@@ -90,7 +90,7 @@ public struct PrayerTimes {
             tempFajr = cal.date(from: fajrComponents)
         }
 
-        // special case for moonsighting committee above latitude 55
+        // special case for moonsighting committee at or above latitude 55
         if calculationParameters.method == .moonsightingCommittee && coordinates.latitude >= 55 {
             let nightFraction = night / 7
             tempFajr = sunriseDate.addingTimeInterval(-nightFraction)
@@ -119,7 +119,7 @@ public struct PrayerTimes {
                 tempIsha = cal.date(from: ishaComponents)
             }
 
-            // special case for moonsighting committee above latitude 55
+            // special case for moonsighting committee at or above latitude 55
             if calculationParameters.method == .moonsightingCommittee && coordinates.latitude >= 55 {
                 let nightFraction = night / 7
                 tempIsha = sunsetDate.addingTimeInterval(nightFraction)


### PR DESCRIPTION
The `moonsightingCommittee` method checks `coordinates.latitude >= 55` in `PrayerTimes.swift`, but the public docs (`METHODS.md` and the `CalculationMethod` doc comment) and the two inline comments said the rule applies *above* 55° latitude, which contradicts the inclusive `>=` check.

This is purely a documentation fix that makes the wording match the actual behavior (consistent with the other methods' docs):

- `METHODS.md` — "above 55° latitude" → "at or above 55° latitude"
- `Sources/Models/CalculationMethod.swift` — same wording fix
- `Sources/PrayerTimes.swift` — update the two inline comments to match the `>=` threshold

Also updates the SPM installation version in `README.md` from 1.4.0 to the current release 1.5.0.

No behavior changes.